### PR TITLE
added implementation of getAhrsData to IMU_6886.cpp

### DIFF
--- a/examples/Unit/IMU_MPU6886/IMU_6886.cpp
+++ b/examples/Unit/IMU_MPU6886/IMU_6886.cpp
@@ -219,6 +219,23 @@ void IMU_6886::getTempData(float *t) {
   *t = (float)temp / 326.8 + 25.0;
 }
 
+// 2021-11-08 aturowsk added code from m5stack MPU6886.cpp implementation to unit code. Needs src/utility/MahonyAHRS.cpp  
+void IMU_6886::getAhrsData(float *pitch, float *roll, float *yaw) {
+
+  float accX = 0; 
+  float accY = 0;
+  float accZ = 0;
+
+  float gyroX = 0;
+  float gyroY = 0;
+  float gyroZ = 0;
+
+
+  getGyroData(&gyroX, &gyroY, &gyroZ);
+  getAccelData(&accX, &accY, &accZ);
+  MahonyAHRSupdateIMU(gyroX * DEG_TO_RAD, gyroY * DEG_TO_RAD, gyroZ * DEG_TO_RAD, accX, accY, accZ, pitch, roll, yaw);
+}
+
 void IMU_6886::setGyroOffset(uint16_t x, uint16_t y, uint16_t z) {
   uint8_t buf_out[6];
   buf_out[0] = x >> 8;

--- a/examples/Unit/IMU_MPU6886/IMU_MPU6886.ino
+++ b/examples/Unit/IMU_MPU6886/IMU_MPU6886.ino
@@ -17,6 +17,10 @@ float gyroX = 0;
 float gyroY = 0;
 float gyroZ = 0;
 
+float pitch = 0.0F;
+float roll  = 0.0F;
+float yaw   = 0.0F;
+
 float temp = 0;
 
 void setup() {
@@ -30,6 +34,8 @@ void setup() {
   M5.Lcd.setTextSize(1);
   M5.Lcd.setCursor(50, 30);
   M5.Lcd.println("  X      Y       Z");
+  M5.Lcd.setCursor(45, 90);
+  M5.Lcd.println("  Pitch   Roll    Yaw");  
   imu6886.Init(32, 33);
 }
 
@@ -38,6 +44,7 @@ void loop() {
   imu6886.getGyroData(&gyroX,&gyroY,&gyroZ);
   imu6886.getAccelData(&accX,&accY,&accZ);
   imu6886.getTempData(&temp);
+  imu6886.getAhrsData(&pitch,&roll,&yaw);
   M5.Lcd.setCursor(45, 45);
   M5.Lcd.printf("%.2f   %.2f   %.2f   ", gyroX, gyroY,gyroZ);
   M5.Lcd.setCursor(185, 45);
@@ -48,5 +55,7 @@ void loop() {
   M5.Lcd.print("G");
   M5.Lcd.setCursor(45, 75);
   M5.Lcd.printf("Temperature : %.2f  C", temp);
+  M5.Lcd.setCursor(45, 105);
+  M5.Lcd.printf(" %5.2f   %5.2f   %5.2f   ", pitch, roll, yaw);  
   delay(100);
 }


### PR DESCRIPTION
Missing implementation of getAhrsData(&pitch,&roll,&yaw) added to the Unit code of IMU_6886.cpp and added display code in IMU_MPU6886.ino

