### PR TITLE
Add support for MPU6886 1kB FIFO buffer to improve IMU sampling precision

### DIFF
--- a/src/utility/MPU6886.cpp
+++ b/src/utility/MPU6886.cpp
@@ -224,103 +224,112 @@ void MPU6886::getTempData(float* t) {
     *t = (float)temp / 326.8 + 25.0;
 }
 
-void MPU6886::enableFIFO (Fodr rate){
+void MPU6886::enableFIFO(Fodr rate) {
+    unsigned char regdata;
 
-  unsigned char regdata;
-  
-  I2C_Read_NBytes(MPU6886_ADDRESS, MPU6886_GYRO_CONFIG, 1, &regdata);
-  regdata &= 0x1C;	//Clear bits 7:5 and 0:1 of FCHOICE_B to enable sample rate divider and DLPF setting
-  I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_GYRO_CONFIG, 1, &regdata);
-  delay(10);
+    I2C_Read_NBytes(MPU6886_ADDRESS, MPU6886_GYRO_CONFIG, 1, &regdata);
+    regdata &= 0x1C;  // Clear bits 7:5 and 0:1 of FCHOICE_B to enable sample
+                      // rate divider and DLPF setting
+    I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_GYRO_CONFIG, 1, &regdata);
+    delay(10);
 
-  regdata = rate & 0xFF;	//Set sample rate clock divider based on passed value for sample rate desired
-  I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_SMPLRT_DIV, 1, &regdata);
-  delay(10);
+    regdata = rate & 0xFF;  // Set sample rate clock divider based on passed
+                            // value for sample rate desired
+    I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_SMPLRT_DIV, 1, &regdata);
+    delay(10);
 
-  I2C_Read_NBytes(MPU6886_ADDRESS, MPU6886_CONFIG, 1, &regdata);
-  regdata |= 0x01;	//Set DLPF_CFG to 176Hz DLPF filtering (highest value where sample rate clock divider still works)
-  regdata &= 0xBF;	//Clear bit 6 to allow overflow writes to the FIFO - Use it, or lose it!
-  I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_CONFIG, 1, &regdata);
-  delay(10);
-  
-  regdata = 0x18;	//Set GYRO_FIFO_EN and ACCEL_FIFO_EN bits to one in FIFO Enable register to enable FIFO on ALL sensor data
-  I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_FIFO_EN, 1, &regdata);
-  delay(10);
+    I2C_Read_NBytes(MPU6886_ADDRESS, MPU6886_CONFIG, 1, &regdata);
+    regdata |= 0x01;  // Set DLPF_CFG to 176Hz DLPF filtering (highest value
+                      // where sample rate clock divider still works)
+    regdata &= 0xBF;  // Clear bit 6 to allow overflow writes to the FIFO - Use
+                      // it, or lose it!
+    I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_CONFIG, 1, &regdata);
+    delay(10);
 
-  I2C_Read_NBytes(MPU6886_ADDRESS, MPU6886_INT_ENABLE, 1, &regdata);
-  regdata |= 0x10;	// Set bit 4 to turn on interrupts on FIFO overflow events
-  I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_INT_ENABLE, 1, &regdata);
-  delay(10);
+    regdata = 0x18;  // Set GYRO_FIFO_EN and ACCEL_FIFO_EN bits to one in FIFO
+                     // Enable register to enable FIFO on ALL sensor data
+    I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_FIFO_EN, 1, &regdata);
+    delay(10);
 
-  regdata = 0x44;	//Set FIFO_EN and FIFO_RST bits to one in User Control register to enable FIFO mode
-  I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_USER_CTRL, 1, &regdata);
-  delay(10);
+    I2C_Read_NBytes(MPU6886_ADDRESS, MPU6886_INT_ENABLE, 1, &regdata);
+    regdata |= 0x10;  // Set bit 4 to turn on interrupts on FIFO overflow events
+    I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_INT_ENABLE, 1, &regdata);
+    delay(10);
+
+    regdata = 0x44;  // Set FIFO_EN and FIFO_RST bits to one in User Control
+                     // register to enable FIFO mode
+    I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_USER_CTRL, 1, &regdata);
+    delay(10);
 }
 
-void MPU6886::resetFIFO (void){
+void MPU6886::resetFIFO(void) {
+    unsigned char regdata;
 
-  unsigned char regdata;
-  
-  I2C_Read_NBytes(MPU6886_ADDRESS, MPU6886_USER_CTRL, 1, &regdata);
-  regdata |= 0x04;	// Set bit 2 to reset FIFO module
-  I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_USER_CTRL, 1, &regdata);
-  delay(10);
+    I2C_Read_NBytes(MPU6886_ADDRESS, MPU6886_USER_CTRL, 1, &regdata);
+    regdata |= 0x04;  // Set bit 2 to reset FIFO module
+    I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_USER_CTRL, 1, &regdata);
+    delay(10);
 }
 
-void MPU6886::disableFIFO (void){
+void MPU6886::disableFIFO(void) {
+    unsigned char regdata;
 
-  unsigned char regdata;
-  
-  regdata = 0x00;	//Clear GYRO_FIFO_EN and ACCEL_FIFO_EN bits to zero in FIFO Enable register
-  I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_FIFO_EN, 1, &regdata);
-  delay(10);
+    regdata = 0x00;  // Clear GYRO_FIFO_EN and ACCEL_FIFO_EN bits to zero in
+                     // FIFO Enable register
+    I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_FIFO_EN, 1, &regdata);
+    delay(10);
 
-  I2C_Read_NBytes(MPU6886_ADDRESS, MPU6886_INT_ENABLE, 1, &regdata);
-  regdata &= 0xEF;	// Clear bit 4 to turn off interrupts on FIFO overflow events
-  I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_INT_ENABLE, 1, &regdata);
-  delay(10);
+    I2C_Read_NBytes(MPU6886_ADDRESS, MPU6886_INT_ENABLE, 1, &regdata);
+    regdata &=
+        0xEF;  // Clear bit 4 to turn off interrupts on FIFO overflow events
+    I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_INT_ENABLE, 1, &regdata);
+    delay(10);
 
-  regdata = 0x00;	//Set FIFO_EN bit to zero in User Control register to dsiable FIFO mode
-  I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_USER_CTRL, 1, &regdata);
-  delay(10);
+    regdata = 0x00;  // Set FIFO_EN bit to zero in User Control register to
+                     // dsiable FIFO mode
+    I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_USER_CTRL, 1, &regdata);
+    delay(10);
 }
 
-int MPU6886::getFIFOData(int16_t databuf[]){
-	
-  uint8_t buf[14];
-  uint8_t i; 
+int MPU6886::getFIFOData(int16_t databuf[]) {
+    uint8_t buf[14];
+    uint8_t i;
 
-  I2C_Read_NBytes(MPU6886_ADDRESS, MPU6886_FIFO_R_W, 14, buf);	//Burst read 14 byte sensor data sample array
-  
-  if ((((uint16_t)buf[0]<<8)|buf[1]) == 0x7F7F) {	// Datasheet suggests 0xFFFF, but not what appears to work
-	  return -1;
-  }
-  databuf[0] = ((int16_t)buf[0]<<8)|buf[1]; //accelX
-  databuf[1] = ((int16_t)buf[2]<<8)|buf[3]; //accelY
-  databuf[2] = ((int16_t)buf[4]<<8)|buf[5]; //accelZ
-  databuf[6] = ((int16_t)buf[6]<<8)|buf[7]; //temp
-  databuf[3] = ((int16_t)buf[8]<<8)|buf[9]; //gyroX 
-  databuf[4] = ((int16_t)buf[10]<<8)|buf[11]; //gyroY
-  databuf[5] = ((int16_t)buf[12]<<8)|buf[13]; //gyroZ
-  return 0;
+    I2C_Read_NBytes(MPU6886_ADDRESS, MPU6886_FIFO_R_W, 14,
+                    buf);  // Burst read 14 byte sensor data sample array
+
+    if ((((uint16_t)buf[0] << 8) | buf[1]) ==
+        0x7F7F) {  // Datasheet suggests 0xFFFF, but not what appears to work
+        return -1;
+    }
+    databuf[0] = ((int16_t)buf[0] << 8) | buf[1];    // accelX
+    databuf[1] = ((int16_t)buf[2] << 8) | buf[3];    // accelY
+    databuf[2] = ((int16_t)buf[4] << 8) | buf[5];    // accelZ
+    databuf[6] = ((int16_t)buf[6] << 8) | buf[7];    // temp
+    databuf[3] = ((int16_t)buf[8] << 8) | buf[9];    // gyroX
+    databuf[4] = ((int16_t)buf[10] << 8) | buf[11];  // gyroY
+    databuf[5] = ((int16_t)buf[12] << 8) | buf[13];  // gyroZ
+    return 0;
 }
 
-int MPU6886::getFIFOData(int16_t* ax, int16_t* ay, int16_t* az, int16_t* gx, int16_t* gy, int16_t* gz, int16_t *t){
-	
-  uint8_t buf[14];
-  uint8_t i; 
+int MPU6886::getFIFOData(int16_t* ax, int16_t* ay, int16_t* az, int16_t* gx,
+                         int16_t* gy, int16_t* gz, int16_t* t) {
+    uint8_t buf[14];
+    uint8_t i;
 
-  I2C_Read_NBytes(MPU6886_ADDRESS, MPU6886_FIFO_R_W, 14, buf);	//Burst read 14 byte sensor data sample array
-  
-  if ((((uint16_t)buf[0]<<8)|buf[1]) == 0x7F7F) {	// Datasheet suggests 0xFFFF, but not what appears to work
-	  return -1;
-  }
-  *ax = ((int16_t)buf[0]<<8)|buf[1];
-  *ay = ((int16_t)buf[2]<<8)|buf[3];
-  *az = ((int16_t)buf[4]<<8)|buf[5];
-  *t = ((int16_t)buf[6]<<8)|buf[7];  
-  *gx = ((int16_t)buf[8]<<8)|buf[9];  
-  *gy = ((int16_t)buf[10]<<8)|buf[11];  
-  *gz = ((int16_t)buf[12]<<8)|buf[13];
-  return 0;
+    I2C_Read_NBytes(MPU6886_ADDRESS, MPU6886_FIFO_R_W, 14,
+                    buf);  // Burst read 14 byte sensor data sample array
+
+    if ((((uint16_t)buf[0] << 8) | buf[1]) ==
+        0x7F7F) {  // Datasheet suggests 0xFFFF, but not what appears to work
+        return -1;
+    }
+    *ax = ((int16_t)buf[0] << 8) | buf[1];
+    *ay = ((int16_t)buf[2] << 8) | buf[3];
+    *az = ((int16_t)buf[4] << 8) | buf[5];
+    *t  = ((int16_t)buf[6] << 8) | buf[7];
+    *gx = ((int16_t)buf[8] << 8) | buf[9];
+    *gy = ((int16_t)buf[10] << 8) | buf[11];
+    *gz = ((int16_t)buf[12] << 8) | buf[13];
+    return 0;
 }

--- a/src/utility/MPU6886.cpp
+++ b/src/utility/MPU6886.cpp
@@ -223,3 +223,104 @@ void MPU6886::getTempData(float* t) {
 
     *t = (float)temp / 326.8 + 25.0;
 }
+
+void MPU6886::enableFIFO (Fodr rate){
+
+  unsigned char regdata;
+  
+  I2C_Read_NBytes(MPU6886_ADDRESS, MPU6886_GYRO_CONFIG, 1, &regdata);
+  regdata &= 0x1C;	//Clear bits 7:5 and 0:1 of FCHOICE_B to enable sample rate divider and DLPF setting
+  I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_GYRO_CONFIG, 1, &regdata);
+  delay(10);
+
+  regdata = rate & 0xFF;	//Set sample rate clock divider based on passed value for sample rate desired
+  I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_SMPLRT_DIV, 1, &regdata);
+  delay(10);
+
+  I2C_Read_NBytes(MPU6886_ADDRESS, MPU6886_CONFIG, 1, &regdata);
+  regdata |= 0x01;	//Set DLPF_CFG to 176Hz DLPF filtering (highest value where sample rate clock divider still works)
+  regdata &= 0xBF;	//Clear bit 6 to allow overflow writes to the FIFO - Use it, or lose it!
+  I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_CONFIG, 1, &regdata);
+  delay(10);
+  
+  regdata = 0x18;	//Set GYRO_FIFO_EN and ACCEL_FIFO_EN bits to one in FIFO Enable register to enable FIFO on ALL sensor data
+  I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_FIFO_EN, 1, &regdata);
+  delay(10);
+
+  I2C_Read_NBytes(MPU6886_ADDRESS, MPU6886_INT_ENABLE, 1, &regdata);
+  regdata |= 0x10;	// Set bit 4 to turn on interrupts on FIFO overflow events
+  I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_INT_ENABLE, 1, &regdata);
+  delay(10);
+
+  regdata = 0x44;	//Set FIFO_EN and FIFO_RST bits to one in User Control register to enable FIFO mode
+  I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_USER_CTRL, 1, &regdata);
+  delay(10);
+}
+
+void MPU6886::resetFIFO (void){
+
+  unsigned char regdata;
+  
+  I2C_Read_NBytes(MPU6886_ADDRESS, MPU6886_USER_CTRL, 1, &regdata);
+  regdata |= 0x04;	// Set bit 2 to reset FIFO module
+  I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_USER_CTRL, 1, &regdata);
+  delay(10);
+}
+
+void MPU6886::disableFIFO (void){
+
+  unsigned char regdata;
+  
+  regdata = 0x00;	//Clear GYRO_FIFO_EN and ACCEL_FIFO_EN bits to zero in FIFO Enable register
+  I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_FIFO_EN, 1, &regdata);
+  delay(10);
+
+  I2C_Read_NBytes(MPU6886_ADDRESS, MPU6886_INT_ENABLE, 1, &regdata);
+  regdata &= 0xEF;	// Clear bit 4 to turn off interrupts on FIFO overflow events
+  I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_INT_ENABLE, 1, &regdata);
+  delay(10);
+
+  regdata = 0x00;	//Set FIFO_EN bit to zero in User Control register to dsiable FIFO mode
+  I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_USER_CTRL, 1, &regdata);
+  delay(10);
+}
+
+int MPU6886::getFIFOData(int16_t databuf[]){
+	
+  uint8_t buf[14];
+  uint8_t i; 
+
+  I2C_Read_NBytes(MPU6886_ADDRESS, MPU6886_FIFO_R_W, 14, buf);	//Burst read 14 byte sensor data sample array
+  
+  if ((((uint16_t)buf[0]<<8)|buf[1]) == 0x7F7F) {	// Datasheet suggests 0xFFFF, but not what appears to work
+	  return -1;
+  }
+  databuf[0] = ((int16_t)buf[0]<<8)|buf[1]; //accelX
+  databuf[1] = ((int16_t)buf[2]<<8)|buf[3]; //accelY
+  databuf[2] = ((int16_t)buf[4]<<8)|buf[5]; //accelZ
+  databuf[6] = ((int16_t)buf[6]<<8)|buf[7]; //temp
+  databuf[3] = ((int16_t)buf[8]<<8)|buf[9]; //gyroX 
+  databuf[4] = ((int16_t)buf[10]<<8)|buf[11]; //gyroY
+  databuf[5] = ((int16_t)buf[12]<<8)|buf[13]; //gyroZ
+  return 0;
+}
+
+int MPU6886::getFIFOData(int16_t* ax, int16_t* ay, int16_t* az, int16_t* gx, int16_t* gy, int16_t* gz, int16_t *t){
+	
+  uint8_t buf[14];
+  uint8_t i; 
+
+  I2C_Read_NBytes(MPU6886_ADDRESS, MPU6886_FIFO_R_W, 14, buf);	//Burst read 14 byte sensor data sample array
+  
+  if ((((uint16_t)buf[0]<<8)|buf[1]) == 0x7F7F) {	// Datasheet suggests 0xFFFF, but not what appears to work
+	  return -1;
+  }
+  *ax = ((int16_t)buf[0]<<8)|buf[1];
+  *ay = ((int16_t)buf[2]<<8)|buf[3];
+  *az = ((int16_t)buf[4]<<8)|buf[5];
+  *t = ((int16_t)buf[6]<<8)|buf[7];  
+  *gx = ((int16_t)buf[8]<<8)|buf[9];  
+  *gy = ((int16_t)buf[10]<<8)|buf[11];  
+  *gz = ((int16_t)buf[12]<<8)|buf[13];
+  return 0;
+}

--- a/src/utility/MPU6886.h
+++ b/src/utility/MPU6886.h
@@ -43,6 +43,9 @@
 #define MPU6886_ACCEL_CONFIG  0x1C
 #define MPU6886_ACCEL_CONFIG2 0x1D
 #define MPU6886_FIFO_EN       0x23
+// add register for R/W FIFO buffer
+#define MPU6886_FIFO_R_W          0x74
+
 
 //#define G (9.8)
 #define RtA     57.324841
@@ -54,6 +57,18 @@ class MPU6886 {
     enum Ascale { AFS_2G = 0, AFS_4G, AFS_8G, AFS_16G };
 
     enum Gscale { GFS_250DPS = 0, GFS_500DPS, GFS_1000DPS, GFS_2000DPS };
+
+// Enumeration type for selecting FIFO output data rate (sample rate)
+	  enum Fodr {
+    ODR_1kHz = 0,
+		  ODR_500Hz = 1,
+		  ODR_250Hz = 3,
+		  ODR_200Hz = 4,
+		  ODR_125Hz = 7,
+		  ODR_100Hz = 9,
+		  ODR_50Hz = 19,
+		  ODR_10Hz = 99
+	  };
 
     Gscale Gyscale = GFS_2000DPS;
     Ascale Acscale = AFS_8G;
@@ -73,6 +88,13 @@ class MPU6886 {
     void SetAccelFsr(Ascale scale);
     void getAhrsData(float* pitch, float* roll, float* yaw);
 
+ //	New public functions of MPU6886 to support FIFO buffered sensor data output
+	   void enableFIFO (Fodr rate);
+	   void resetFIFO (void);
+	   void disableFIFO (void);
+	   int getFIFOData(int16_t databuf[]);
+	   int getFIFOData(int16_t* ax, int16_t* ay, int16_t* az, int16_t *t, int16_t* gx, int16_t* gy, int16_t* gz);
+ 
    public:
     float aRes, gRes;
 

--- a/src/utility/MPU6886.h
+++ b/src/utility/MPU6886.h
@@ -44,8 +44,7 @@
 #define MPU6886_ACCEL_CONFIG2 0x1D
 #define MPU6886_FIFO_EN       0x23
 // add register for R/W FIFO buffer
-#define MPU6886_FIFO_R_W          0x74
-
+#define MPU6886_FIFO_R_W 0x74
 
 //#define G (9.8)
 #define RtA     57.324841
@@ -58,17 +57,17 @@ class MPU6886 {
 
     enum Gscale { GFS_250DPS = 0, GFS_500DPS, GFS_1000DPS, GFS_2000DPS };
 
-// Enumeration type for selecting FIFO output data rate (sample rate)
-	  enum Fodr {
-    ODR_1kHz = 0,
-		  ODR_500Hz = 1,
-		  ODR_250Hz = 3,
-		  ODR_200Hz = 4,
-		  ODR_125Hz = 7,
-		  ODR_100Hz = 9,
-		  ODR_50Hz = 19,
-		  ODR_10Hz = 99
-	  };
+    // Enumeration type for selecting FIFO output data rate (sample rate)
+    enum Fodr {
+        ODR_1kHz  = 0,
+        ODR_500Hz = 1,
+        ODR_250Hz = 3,
+        ODR_200Hz = 4,
+        ODR_125Hz = 7,
+        ODR_100Hz = 9,
+        ODR_50Hz  = 19,
+        ODR_10Hz  = 99
+    };
 
     Gscale Gyscale = GFS_2000DPS;
     Ascale Acscale = AFS_8G;
@@ -88,13 +87,15 @@ class MPU6886 {
     void SetAccelFsr(Ascale scale);
     void getAhrsData(float* pitch, float* roll, float* yaw);
 
- //	New public functions of MPU6886 to support FIFO buffered sensor data output
-	   void enableFIFO (Fodr rate);
-	   void resetFIFO (void);
-	   void disableFIFO (void);
-	   int getFIFOData(int16_t databuf[]);
-	   int getFIFOData(int16_t* ax, int16_t* ay, int16_t* az, int16_t *t, int16_t* gx, int16_t* gy, int16_t* gz);
- 
+    //	New public functions of MPU6886 to support FIFO buffered sensor data
+    // output
+    void enableFIFO(Fodr rate);
+    void resetFIFO(void);
+    void disableFIFO(void);
+    int getFIFOData(int16_t databuf[]);
+    int getFIFOData(int16_t* ax, int16_t* ay, int16_t* az, int16_t* t,
+                    int16_t* gx, int16_t* gy, int16_t* gz);
+
    public:
     float aRes, gRes;
 


### PR DESCRIPTION
Existing library allows for polled sample reads of the MPU6886 IMU sensor.  Additions in this pull request add support for the MPU6886 FIFO mode that allow more precise sampling by setting a sample rate for FIFO buffering of sample data with burst reads from the host ESP32 application.