### PR TITLE
Fixed Arduino Compile Errors

### DIFF
--- a/src/utility/In_eSPI.h
+++ b/src/utility/In_eSPI.h
@@ -19,6 +19,9 @@
 
 //#define ESP32 //Just used to test ESP32 options
 
+// Include hal/gpio to fix Espressif hiding GPIO from public use
+#include "hal/gpio_ll.h"
+
 // Include header file that defines the fonts loaded, the TFT drivers
 // available and the pins to be used
 #include "In_eSPI_Setup.h"

--- a/src/utility/Speaker.cpp
+++ b/src/utility/Speaker.cpp
@@ -7,14 +7,13 @@ SPEAKER::SPEAKER(void) {
 
 void SPEAKER::begin() {
     _begun = true;
-    ledcSetup(TONE_PIN_CHANNEL, 0, 13);
-    ledcAttachPin(SPEAKER_PIN, TONE_PIN_CHANNEL);
+    ledcAttach(TONE_PIN_CHANNEL, 0, 13);
     setBeep(4000, 100);
 }
 
 void SPEAKER::end() {
     mute();
-    ledcDetachPin(SPEAKER_PIN);
+    ledcDetach(SPEAKER_PIN);
     _begun = false;
 }
 
@@ -75,6 +74,5 @@ void SPEAKER::playMusic(const uint8_t* music_data, uint16_t sample_rate) {
             delay(2);
         }
     }
-    // ledcSetup(TONE_PIN_CHANNEL, 0, 13);
-    ledcAttachPin(SPEAKER_PIN, TONE_PIN_CHANNEL);
+    ledcAttach(TONE_PIN_CHANNEL, 0, 13);
 }

--- a/src/utility/Speaker.cpp
+++ b/src/utility/Speaker.cpp
@@ -7,13 +7,22 @@ SPEAKER::SPEAKER(void) {
 
 void SPEAKER::begin() {
     _begun = true;
-    ledcAttach(TONE_PIN_CHANNEL, 0, 13);
+#if ESP_IDF_VERSION_MAJOR <= 4
+    ledcSetup(TONE_PIN_CHANNEL, 0, 13);
+    ledcAttachPin(SPEAKER_PIN, TONE_PIN_CHANNEL);
+#elif ESP_IDF_VERSION_MAJOR > 4
+    ledcAttach(SPEAKER_PIN, 0, 13);
+#endif
     setBeep(4000, 100);
 }
 
 void SPEAKER::end() {
     mute();
+#if ESP_IDF_VERSION_MAJOR <= 4
+    ledcDetachPin(SPEAKER_PIN);
+#elif ESP_IDF_VERSION_MAJOR > 4
     ledcDetach(SPEAKER_PIN);
+#endif
     _begun = false;
 }
 
@@ -74,5 +83,9 @@ void SPEAKER::playMusic(const uint8_t* music_data, uint16_t sample_rate) {
             delay(2);
         }
     }
-    ledcAttach(TONE_PIN_CHANNEL, 0, 13);
+#if ESP_IDF_VERSION_MAJOR <= 4
+    ledcAttachPin(SPEAKER_PIN, TONE_PIN_CHANNEL);
+#elif ESP_IDF_VERSION_MAJOR > 4
+    ledcAttach(SPEAKER_PIN, 0, 13);
+#endif
 }


### PR DESCRIPTION
Arduino compile errors were caused by updates to ESP_IDF and ESP32 Core.

Migrated Speaker.cpp to V3.0.0 standards following the migration guide here:
https://github.com/espressif/arduino-esp32/blob/master/docs/en/migration_guides/2.x_to_3.0.rst#ledc

Fixed GPIO errors by including hal/gpio_ll.h in In_eSPI.h to return access to utilized GPIO struct.